### PR TITLE
Change to fedora base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM quay.io/ukhomeofficedigital/docker-centos-base
+FROM fedora:22
 
-RUN yum update -y -q; yum clean all
+RUN dnf update -y -q; dnf clean all
 ADD logstash-1.5.repo /etc/yum.repos.d/logstash-1.5.repo
-RUN yum install -y -q java-1.8.0-openjdk-headless.x86_64 logstash-1.5.4-1.noarch; yum clean all
+RUN dnf install -y -q java-1.8.0-openjdk-headless.x86_64 logstash which; dnf clean all
+
+ENV PATH=${PATH}:/opt/logstash/bin
 
 RUN /opt/logstash/bin/plugin install logstash-filter-kubernetes
 RUN /opt/logstash/bin/plugin install logstash-filter-json_encode


### PR DESCRIPTION
I found it not possible to make certain logstash plugins work in CentOS
while they perfectly work in Debian or Fedora.
