### PR TITLE
conf: add prefix to cloudwatch stream names

### DIFF
--- a/conf.d/20_output_journald_cloudwatch.conf
+++ b/conf.d/20_output_journald_cloudwatch.conf
@@ -42,7 +42,7 @@ output {
     cloudwatchlogs {
       region => "%AWS_REGION%"
       log_group_name => "%LOG_GROUP_NAME%"
-      log_stream_name => "%LOG_STREAM_NAME%"
+      log_stream_name => "journald/%LOG_STREAM_NAME%"
     }
   }
 }

--- a/conf.d/20_output_kubernetes_cloudwatch.conf
+++ b/conf.d/20_output_kubernetes_cloudwatch.conf
@@ -44,7 +44,7 @@ output {
     cloudwatchlogs {
       region => "%AWS_REGION%"
       log_group_name => "%LOG_GROUP_NAME%"
-      log_stream_name => "%LOG_STREAM_NAME%"
+      log_stream_name => "kubernetes/%LOG_STREAM_NAME%"
     }
   }
 }


### PR DESCRIPTION
Just to work around the limitation of cloudwatchlogs plugin not being
able to dynamically generate log group and stream names.

See the following issue for more details:
https://github.com/awslabs/logstash-output-cloudwatchlogs/issues/2
