### PR TITLE
Added an additional output for gelf upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ As usual, configuration is passed through environment variables.
 - `LOG_GROUP_NAME` - Cloudwatch logs group name. Defaults to `logstash`.
 - `LOG_STREAM_NAME` - Cloudwatch logs stream name. Defaults to `hostname()`.
 
+### Gelf Logs
+
+- OUTPUT_GELF - whether to enable this output. Defaults to `false`
+- GELF_HOST - the hostname of a gelf server to send the messages to 
+- GELF_PORT - the port for use on the gelf server. Default to 12201
 
 ## Running
 
@@ -76,5 +81,17 @@ $ docker run -ti --rm \
     -e AWS_REGION=us-west-1 \
     -e AWS_ACCESS_KEY_ID=<REPLACE ME> \
     -e AWS_SECRET_ACCESS_KEY=<REPLACE ME> \
+    quay.io/ukhomeofficedigital/logstash-kubernetes:latest
+```
+
+```
+$ docker run -ti --rm \
+    -v /var/lib/logstash-kubernetes:/var/lib/logstash \
+    -v /var/log/journal:/var/log/journal:ro \
+    -v /var/lib/docker/containers:/var/lib/docker/containers \
+    -v /var/log/containers:/var/log/containers \
+    -e OUTPUT_CLOUDWATCH=false \
+    -e OUTPUT_GELF=true \
+    -e GELF_HOST=<REPLACE ME> \
     quay.io/ukhomeofficedigital/logstash-kubernetes:latest
 ```

--- a/conf.d/21_output_journald_gelf.conf
+++ b/conf.d/21_output_journald_gelf.conf
@@ -1,0 +1,23 @@
+# Mutate events to be suitable for pushing to gelf 
+filter {
+  if "journald" in [tags] {
+    # check if message looks like json and try to decode it
+    if [message] =~ /^{.*}$/ {
+      json {
+        source => "message"
+        target => "journal"
+        add_tag => [ "journal_json" ]
+      }
+   
+    }
+  }
+}
+
+output {
+  if "journald" in [tags] {
+    gelf {
+	host => "%GELF_HOST%"
+        port => %GELF_PORT%
+    }
+  }
+}

--- a/conf.d/21_output_kubernetes_gelf.conf
+++ b/conf.d/21_output_kubernetes_gelf.conf
@@ -1,4 +1,4 @@
-# Mutate events to be suitable for pushing to Cloudwatch Logs
+# Mutate events to be suitable for pushing to gelf 
 filter {
   if "kubernetes" and "docker" in [tags] {
     # check if message looks like json and try to decode it

--- a/conf.d/21_output_kubernetes_gelf.conf
+++ b/conf.d/21_output_kubernetes_gelf.conf
@@ -1,0 +1,45 @@
+# Mutate events to be suitable for pushing to Cloudwatch Logs
+filter {
+  if "kubernetes" and "docker" in [tags] {
+    # check if message looks like json and try to decode it
+    if [message] =~ /^{.*}$/ {
+      json {
+        source => "message"
+        target => "container"
+        add_tag => [ "container_json" ]
+      }
+
+    }
+
+    # check if message["log"] looks like json and try to decode it and flatten
+    # log fields out into a message field
+    if [container][log] =~ /^{.*}$/ {
+      json {
+        source => "[container][log]"
+        target => "[container]"
+        remove_field => [ "[container][log]" ]
+        add_tag => [ "container_app_json" ]
+      }
+    }
+
+    # Grab a timestamp from the actual message, rather than at the point of
+    # which events arrive
+    date {
+      match => ["[container][time]", "ISO8601"]
+    }
+
+    # Extract kubernetes metadata
+    kubernetes {
+      add_tag => ["kubernetes_filtered"]
+    }
+  }
+}
+
+output {
+  if "kubernetes_filtered" in [tags] {
+    gelf {
+	host => "%GELF_HOST%"
+	port => %GELF_PORT%
+    }
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,14 @@
 : ${AWS_REGION:=eu-west-1}
 : ${LOG_GROUP_NAME:=logstash}
 : ${LOG_STREAM_NAME:=$(hostname)}
+: ${OUTPUT_GELF:=false}
+: ${GELF_HOST:=""}
+: ${GELF_PORT:=12201}
+
+sed -e "s/%GELF_HOST%/${GELF_HOST}/" \
+    -e "s/%GELF_PORT%/${GELF_PORT}/" \
+    -i /etc/logstash/conf.d/21_output_kubernetes_gelf.conf \
+    -i /etc/logstash/conf.d/21_output_journald_gelf.conf
 
 sed -e "s/%AWS_REGION%/${AWS_REGION}/" \
     -e "s/%LOG_GROUP_NAME%/${LOG_GROUP_NAME}/" \
@@ -19,6 +27,11 @@ sed -e "s/%AWS_REGION%/${AWS_REGION}/" \
 if [[ ${OUTPUT_CLOUDWATCH} != 'true' ]]; then
   rm -f /etc/logstash/conf.d/20_output_kubernetes_cloudwatch.conf
   rm -f /etc/logstash/conf.d/20_output_journald_cloudwatch.conf
+fi
+
+if [[ ${OUTPUT_GELF} != "true" ]]; then
+  rm -f /etc/logstash/conf.d/21_output_kubernetes_gelf.conf
+  rm -f /etc/logstash/conf.d/21_output_journald_gelf.conf
 fi
 
 ulimit -n ${LS_OPEN_FILES} > /dev/null


### PR DESCRIPTION
Since this uses logstash, it will allow you to send the same data to an upstream logstash instance
or to cloudwatch or to both.
