### PR TITLE
Updates logstash to 5.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN /logstash/bin/logstash-plugin install --version 5.4.0 logstash-output-elasti
 COPY run.sh /run.sh
 COPY conf.d/ /logstash/conf.d/
 
+RUN set -ex; \
+# if the "log4j2.properties" file exists (logstash 5.x), let's empty it out 
+# so we get the default: "logging only errors to the console"
+  if [ -f "/logstash/config/log4j2.properties" ]; then \
+    cp "/logstash/config/log4j2.properties" "/logstash/config/log4j2.properties.dist"; \
+    truncate --size=0 "/logstash/config/log4j2.properties"; \
+  fi
+
 WORKDIR /var/lib/logstash
 VOLUME /var/lib/logstash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ RUN dnf upgrade -y -q && \
     dnf install -y -q java-headless which hostname tar wget && \
     dnf clean all
 
-ENV LS_VERSION 2.4.1
-RUN wget -q https://download.elastic.co/logstash/logstash/logstash-${LS_VERSION}.tar.gz -O - | tar -xzf -; \
+ENV LS_VERSION 5.1.1
+RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-${LS_VERSION}.tar.gz -O - | tar -xzf -; \
   mv logstash-${LS_VERSION} /logstash
 
-RUN /logstash/bin/logstash-plugin install --version 2.7.1 logstash-output-elasticsearch && \
-    /logstash/bin/logstash-plugin install logstash-filter-kubernetes && \
-    /logstash/bin/logstash-plugin install logstash-input-journald && \
-    /logstash/bin/logstash-plugin install --version 2.0.0.pre1 logstash-output-cloudwatchlogs
+RUN /logstash/bin/logstash-plugin install --version 5.4.0 logstash-output-elasticsearch && \
+    /logstash/bin/logstash-plugin install --version 0.3.1 logstash-filter-kubernetes && \
+    /logstash/bin/logstash-plugin install --version 2.0.0 logstash-input-journald
+
 
 COPY run.sh /run.sh
 COPY conf.d/ /logstash/conf.d/

--- a/conf.d/20_output_journald_elasticsearch.conf
+++ b/conf.d/20_output_journald_elasticsearch.conf
@@ -35,6 +35,7 @@ output {
       index => "journald-%ELASTICSEARCH_INDEX_SUFFIX%%{+YYYY.MM.dd}"
       document_type => "%{transport}"
       hosts => [ "%ELASTICSEARCH_HOST%" ]
+      validate_after_inactivity => 60
     }
   }
 }

--- a/conf.d/20_output_kubernetes_elasticsearch.conf
+++ b/conf.d/20_output_kubernetes_elasticsearch.conf
@@ -47,6 +47,7 @@ output {
       index => "kubernetes-%ELASTICSEARCH_INDEX_SUFFIX%%{+YYYY.MM.dd}"
       document_type => "%{[kubernetes][namespace]}_%{[kubernetes][pod]}_%{[kubernetes][container_name]}"
       hosts => [ "%ELASTICSEARCH_HOST%" ]
+      validate_after_inactivity => 60
     }
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -51,4 +51,4 @@ fi
 
 ulimit -n ${LS_OPEN_FILES} > /dev/null
 
-exec /logstash/bin/logstash --log-in-json -f /logstash/conf.d ${LOGSTASH_ARGS}
+exec /logstash/bin/logstash --log.format json -f /logstash/conf.d ${LOGSTASH_ARGS}


### PR DESCRIPTION
* Bumps Logstash version to 5.1.1. 
* Removes logstash-output-cloudwatchlogs as it's incompatible with 5.x

- [x] Depends on: https://github.com/vaijab/logstash-filter-kubernetes/pull/7