### PR TITLE
Filter out messages exceeding 20kB in size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-${LS_VERSIO
 
 RUN /logstash/bin/logstash-plugin install --version 6.2.1 logstash-output-elasticsearch && \
     /logstash/bin/logstash-plugin install --version 0.3.1 logstash-filter-kubernetes && \
+    /logstash/bin/logstash-plugin install --version 1.0.0 logstash-filter-truncate && \
     /logstash/bin/logstash-plugin install --version 2.0.0 logstash-input-journald
 
 COPY run.sh /run.sh

--- a/conf.d/20_output_journald_elasticsearch.conf
+++ b/conf.d/20_output_journald_elasticsearch.conf
@@ -26,6 +26,12 @@ filter {
       rename => { "_pid" => "pid" }
       rename => { "_uid" => "uid" }
     }
+
+    # Remove messages bigger than ~20kB in size to stop LS sending bulks which are too big.
+    # This calculation is based on default ES max bulk size of 100MB and LS flush_size of 5000.
+    truncate {
+      length_bytes => 20000
+    }
   }
 }
 

--- a/conf.d/20_output_kubernetes_elasticsearch.conf
+++ b/conf.d/20_output_kubernetes_elasticsearch.conf
@@ -6,6 +6,13 @@ filter {
       remove_field => [ "[message][stream]" ]
     }
 
+    # Remove messages bigger than ~20kB in size to stop LS sending bulks which are too big.
+    # This calculation is based on default ES max bulk size of 100MB and LS flush_size of 5000.
+    truncate {
+      fields => "message"
+      length_bytes => 20000
+    }
+
     # Grab a timestamp from the actual message, rather than at the point of
     # which events arrive
     if [message][time] {


### PR DESCRIPTION
We've seen bulks from LS exceeding default ES bulk size so this should prevent that.