### PR TITLE
Change kubernetes index types

### DIFF
--- a/conf.d/20_output_kubernetes_elasticsearch.conf
+++ b/conf.d/20_output_kubernetes_elasticsearch.conf
@@ -45,7 +45,7 @@ output {
   if "kubernetes_filtered" in [tags] {
     elasticsearch {
       index => "kubernetes-%ELASTICSEARCH_INDEX_SUFFIX%%{+YYYY.MM.dd}"
-      document_type => "%{[kubernetes][namespace]}_%{[kubernetes][pod]}_%{[kubernetes][container_name]}"
+      document_type => "kubernetes"
       hosts => [ "%ELASTICSEARCH_HOST%" ]
       validate_after_inactivity => 60
       idle_flush_time => %ELASTICSEARCH_IDLE_FLUSH_TIME%


### PR DESCRIPTION
Apparently elasticsearch locks up when there are many different types
in one index.