### PR TITLE
Upgrade LS to 5.3.2 for London region support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf upgrade -y -q && \
     dnf install -y -q java-headless which hostname tar wget && \
     dnf clean all
 
-ENV LS_VERSION 5.1.2
+ENV LS_VERSION 5.3.2
 RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-${LS_VERSION}.tar.gz -O - | tar -xzf -; \
   mv logstash-${LS_VERSION} /logstash
 


### PR DESCRIPTION
added in https://github.com/logstash-plugins/logstash-mixin-aws/releases/tag/v4.2.1