### PR TITLE
Fixes kubernetes audit logs transformation for k8s 1.8 onwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ docker run -ti --rm \
     -v /var/log/journal:/var/log/journal:ro \
     -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
     -v /var/log/containers:/var/log/containers:ro \
+    -v /var/log/kubernetes:/var/log/kubernetes:ro \
     -e ELASTICSEARCH_HOST=my-est-host.local:9200 \
-    quay.io/ukhomeofficedigital/logstash-kubernetes:v0.4.0
+    quay.io/ukhomeofficedigital/logstash-kubernetes:latest
 ```

--- a/conf.d/20_output_kubernetes_audit_elasticsearch.conf
+++ b/conf.d/20_output_kubernetes_audit_elasticsearch.conf
@@ -1,62 +1,20 @@
 filter {
-  if "kubernetes" and "audit" in [tags] {
-    # Splitting original message to get access to event timestamp.
-    mutate {
-      split => { 
-        "message" => " " 
-      }
-    }
+  # parse log entry as json
+  json {
+    source => "message"
+    target => "audit"
+  }
 
-    # Extract timestamp of the acutal event and overwrite @timestamp
-    date {
-      match => [ "[message][0]", "ISO8601"]
-    }
+  # Extract timestamp of the acutal event and overwrite @timestamp
+  date {
+    match => [ "[audit][timestamp]", "ISO8601"]
+  }
 
-    # Extract event key-values
-    kv {
-      field_split => " "
-      value_split => "="
-      target => "message"
-    }
-
-    # If URI present
-    if [message][uri] {
-      # Decode endpoint URL
-      urldecode {
-        field => "[message][uri]"
-      }
-      
-      # Temporarily split URI into endpoint / query_string parts
-      mutate {
-        split => { 
-          "[message][uri]" => "?"
-        }
-      }
-
-      # If query_string exists split them into KV pairs
-      if [message][uri][1] {
-        kv {
-          source => "[message][uri][1]"
-          target => "[message][query_params]"
-          field_split => "&"
-          value_split => "="
-          add_field => { "[message][endpoint]" => "%{[message][uri][0]}" }
-          remove_field => "[message][uri]"
-          allow_duplicate_values => false
-        }
-      } else if [message][uri][0] { # No query_string present
-        mutate {
-          add_field => { "[message][endpoint]" => "%{[message][uri][0]}" }
-          remove_field => "[message][uri]"
-        }        
-      }
-    }
-
-    # Rename field to prevent conflicts with other document types
-    mutate {
-      rename => { "message" => "audit" }
-      add_tag => ["kubernetes_audit_filtered"]
-    }
+  # remove original log entry, add tag
+  mutate {
+    remove_field => "message"
+    remove_field => "[audit][timestamp]"
+    add_tag => ["kubernetes_audit_filtered"]
   }
 }
 
@@ -76,4 +34,3 @@ output {
     }
   }
 }
-


### PR DESCRIPTION
format of audit logs changed from k8s 1.8 onward. Old format is now deprecated and will be removed in 1.12. 