### PR TITLE
6.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,33 @@
 # CHANGELOG
 
-## 5.6.16-2
+## 6.8.1-1
+
+Upgrades Logstash to version 6.8.1: https://www.elastic.co/guide/en/logstash/6.8/releasenotes.html
+
+Bumps journald plugin version
+
+Installs statsd plugin as no longer part of the standard install.
+
+The following environment variables are ADDED:
+
+* `LS_NODE_NAME`
+* `LS_HTTP_HOST`
+
+Options added to README:
+
+* `LS_JAVA_OPTS`
+
+The following environment variables are REMOVED (unused):
+
+* `LS_LOG_DIR`
+
+## 5.6.16-1
+
+Upgrades Logstash to version 5.6.16: https://www.elastic.co/guide/en/logstash/5.6/releasenotes.html
 
 Added options:
 
-- LS_MONITORING_ENABLE - Whether to enable Logstash xpaxk monitoring. Default: `false`
+- LS_MONITORING_ENABLE - Whether to enable Logstash xpack monitoring. Default: `false`
 - ELASTICSEARCH_SCHEME - Elasticsearch HTTP scheme. Default: `http`.
 
 ### Notes:
@@ -20,3 +43,5 @@ The following, for example, should be removed:
 ```
 
 If in doubt, check Management > Upgrade Assistant > Indices in Kibana, which was added in v5.6, or the deprecation messages in log output.
+
+# END

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ RUN dnf upgrade -y -q && \
     dnf install -y -q java-headless which hostname tar wget && \
     dnf clean all
 
-ENV LS_VERSION 5.6.16
+ENV LS_VERSION 6.8.1
 
 RUN wget -q https://artifacts.elastic.co/downloads/logstash/logstash-${LS_VERSION}.tar.gz -O - | tar -xzf -; \
   mv logstash-${LS_VERSION} /logstash
 
 RUN JARS_SKIP=true /logstash/bin/logstash-plugin install --version 0.3.1 logstash-filter-kubernetes && \
-    JARS_SKIP=true /logstash/bin/logstash-plugin install --version 2.0.0 logstash-input-journald && \
-    JARS_SKIP=true /logstash/bin/logstash-plugin install x-pack
+    JARS_SKIP=true /logstash/bin/logstash-plugin install --version 2.0.2 logstash-input-journald && \
+    JARS_SKIP=true /logstash/bin/logstash-plugin install --version 3.2.0 logstash-output-statsd
 
 COPY run.sh /run.sh
 COPY conf.d/ /logstash/conf.d/

--- a/README.md
+++ b/README.md
@@ -30,10 +30,13 @@ journal logs from the beginning after a restart, make sure you mount
 
 As usual, configuration is passed through environment variables.
 
-- `LS_HEAP_SIZE` - logstash JVM heap size. Defaults to `500m`.
+- `LS_HEAP_SIZE` - Logstash JVM heap size. Defaults to `500m`.
 - `LS_LOG_LEVEL` - Logstash log level. Default: `error`.
+- `LS_NODE_NAME` - Logstash node name reported to ES if `LS_MONITORING_ENABLE=true`. Default: `$HOSTNAME`
 - `LS_PIPELINE_BATCH_SIZE` - Size of batches the pipeline is to work in. Default: `125`
-- `LS_MONITORING_ENABLE` - Whether to enable Logstash xpaxk monitoring. Default: `false`
+- `LS_MONITORING_ENABLE` - Whether to enable Logstash xpack monitoring. Default: `false`
+- `LS_HTTP_HOST` - Listen address. default: `0.0.0.0`.
+- `LS_JAVA_OPTS` - JVM Options. Default: `-Djava.io.tmpdir=${HOME}`
 - `INPUT_KUBERNETES` - Enable kubernetes logs ingestion. Default: `true`.
 - `INPUT_KUBERNETES_EXCLUDE_PATTERNS` - Comma separated list of log file path patterns to be excluded from processing. Example: `"*.gz", "*.tar"`. Default: `""`.
 - `INPUT_JOURNALD` - Enable logs ingestion from journald. Default: `true`.

--- a/config/logstash.yml
+++ b/config/logstash.yml
@@ -1,4 +1,6 @@
 ---
+node.name: %LS_NODE_NAME%
+http.host: %LS_HTTP_HOST%
 xpack.monitoring.enabled: %LS_MONITORING_ENABLE%
 xpack.monitoring.elasticsearch.url: %ELASTICSEARCH_SCHEME%://%ELASTICSEARCH_HOST%
 xpack.monitoring.elasticsearch.username: %ELASTICSEARCH_USER%

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,11 @@ export HOME=/var/lib/logstash
 : ${LS_LOG_LEVEL:=error}
 : ${LS_HEAP_SIZE:=500m}
 : ${LS_JAVA_OPTS:=-Djava.io.tmpdir=${HOME}}
-: ${LS_LOG_DIR:=/var/lib/logstash}
 : ${LS_OPEN_FILES:=8192}
 : ${LS_PIPELINE_BATCH_SIZE:=125}
 : ${LS_MONITORING_ENABLE:=false}
+: ${LS_NODE_NAME:=$HOSTNAME}
+: ${LS_HTTP_HOST:=0.0.0.0}
 : ${INPUT_KUBERNETES_EXCLUDE_PATTERNS:=}
 : ${INPUT_JOURNALD:=true}
 : ${INPUT_KUBERNETES_AUDIT:=true}
@@ -74,6 +75,8 @@ else
       -e "s/%ELASTICSEARCH_FLUSH_SIZE_CONFIG%/${ELASTICSEARCH_FLUSH_SIZE_CONFIG}/" \
       -e "s/%ELASTICSEARCH_SCHEME%/${ELASTICSEARCH_SCHEME}/" \
       -e "s/%LS_MONITORING_ENABLE%/${LS_MONITORING_ENABLE}/" \
+      -e "s/%LS_NODE_NAME%/${LS_NODE_NAME}/" \
+      -e "s/%LS_HTTP_HOST%/${LS_HTTP_HOST}/" \
       -i /logstash/config/logstash.yml \
       -i /logstash/conf.d/20_output_kubernetes_elasticsearch.conf \
       -i /logstash/conf.d/20_output_kubernetes_audit_elasticsearch.conf \


### PR DESCRIPTION
Upgrades binaries to 6.8.1
Bumps plugin logstash-input-journald to v2.0.2
Explicitly installs logstash-output-statsd as no longer bundled
Removes document_type from outputs
https://www.elastic.co/guide/en/logstash/6.7/breaking-changes.html#_elasticsearch_output_changes