### PR TITLE
parse logstash.yml even if OUTPUT_ELASTICSEARCH is untrue

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -55,6 +55,16 @@ if [[ ${OUTPUT_ELASTICSEARCH} != 'true' ]]; then
   rm -f /logstash/conf.d/20_output_journald_elasticsearch.conf
   rm -f /logstash/conf.d/20_output_kubernetes_elasticsearch.conf
   rm -f /logstash/conf.d/20_output_kubernetes_audit_elasticsearch.conf
+
+  # Remove outputs, however still populate default values for logstash.yml
+  sed -e "s/%ELASTICSEARCH_HOST%/${ELASTICSEARCH_HOST}/" \
+      -e "s/%ELASTICSEARCH_PASSWORD%/${ELASTICSEARCH_PASSWORD}/" \
+      -e "s/%ELASTICSEARCH_SCHEME%/${ELASTICSEARCH_SCHEME}/" \
+      -e "s/%ELASTICSEARCH_USER%/${ELASTICSEARCH_USER}/" \
+      -e "s/%LS_HTTP_HOST%/${LS_HTTP_HOST}/" \
+      -e "s/%LS_MONITORING_ENABLE%/${LS_MONITORING_ENABLE}/" \
+      -e "s/%LS_NODE_NAME%/${LS_NODE_NAME}/" \
+      -i /logstash/config/logstash.yml
 else
   sed -e "s/%ELASTICSEARCH_HOST%/${ELASTICSEARCH_HOST}/" \
       -e "s/%ELASTICSEARCH_SSL_ENABLED%/${ELASTICSEARCH_SSL_ENABLED}/" \


### PR DESCRIPTION
Logstash will fail to start when trying to run the container with the flag `OUTPUT_ELASTICSEARCH=false` - once set false, default values will not be populated and replaced within `logstash.yml` as shown [on L69-81](https://github.com/UKHomeOffice/docker-logstash-kubernetes/blob/cfa996f648a5007726a9b30e8a5cd7a14a884ad8/run.sh#L69-L81):

```
ERROR: Failed to parse YAML file "/logstash/config/logstash.yml". 
Please confirm if the YAML structure is valid (e.g. look for incorrect usage of whitespace or indentation). 
Aborting... parser_error=>(<unknown>): found character % '%' that cannot start any token. (Do not use % for indentation) while scanning for the next token at line 2 column 27
```